### PR TITLE
Corrected exit codes on errors

### DIFF
--- a/freight.js
+++ b/freight.js
@@ -78,7 +78,7 @@ module.exports = function () {
           function (err) {
             log.error(err);
             if (!options.server) {
-              process.exit(0);
+              process.exit(1);
             }
           }
         );

--- a/lib/startup.js
+++ b/lib/startup.js
@@ -131,7 +131,7 @@ module.exports = function(log) {
         function (err) {
           log.error(err);
           if (!options.server) {
-            process.exit(0);
+            process.exit(1);
           }
         }
       );


### PR DESCRIPTION
@vladikoff

This PR sends a `1` error code on errors that the freight tool runs into. This makes the CLI more useful for shell scripting, et al..

cc/ @jamesreggio
