### PR TITLE
Fix Win32 npm rebuild command

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -147,7 +147,7 @@ module.exports = function (log) {
     // if this project extracted node_modules
     fs.exists('node_modules', function (exists) {
       if (exists) {
-        var npmRebuild = spawn('npm', ['rebuild'], { cwd: process.cwd() });
+        var npmRebuild = spawn(process.platform === 'win32' ? 'npm.bat' : 'npm', ['rebuild'], { cwd: process.cwd() });
         var errorOutput = null;
 
         log.info('Running NPM rebuild...');


### PR DESCRIPTION
Under Windows, using freight get current fails at the rebuild step.

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:1011:11)
    at Process.ChildProcess._handle.onexit (child_process.js:802:34)
```

`spawn()` requires the full executable file name under windows, which is normally `npm.bat`.